### PR TITLE
feat(game): editable player names with inline click-to-edit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,14 @@
 import { useGame } from '@/features/game/useGame'
 import { useConfetti } from '@/features/game/useConfetti'
+import { usePlayerNames } from '@/features/game/usePlayerNames'
 import { GameBoard } from '@/features/game/GameBoard'
 import { GameStatus } from '@/features/game/GameStatus'
+import { PlayerNames } from '@/features/game/PlayerNames'
 import { Button } from '@/components/ui/Button'
 
 export default function App() {
   const { board, status, makeMove, resetGame } = useGame()
+  const { names, setName } = usePlayerNames()
   useConfetti(status)
 
   return (
@@ -13,12 +16,9 @@ export default function App() {
       <div className="flex flex-col items-center gap-8">
         <h1 className="text-3xl font-bold text-white tracking-tight">Tres en Raya</h1>
 
-        <div className="flex gap-6 text-sm font-semibold">
-          <span className="text-indigo-400">X — Jugador 1</span>
-          <span className="text-rose-400">O — Jugador 2</span>
-        </div>
+        <PlayerNames names={names} onSetName={setName} />
 
-        <GameStatus status={status} />
+        <GameStatus status={status} names={names} />
 
         <GameBoard board={board} status={status} onMove={makeMove} />
 

--- a/src/features/game/GameStatus.tsx
+++ b/src/features/game/GameStatus.tsx
@@ -1,26 +1,35 @@
 import type { GameStatus as TGameStatus } from '@/types'
+import type { PlayerNames } from './usePlayerNames'
 
 interface GameStatusProps {
   status: TGameStatus
+  names: PlayerNames
 }
 
-export function GameStatus({ status }: GameStatusProps) {
+const playerColor: Record<'X' | 'O', string> = {
+  X: 'text-indigo-400',
+  O: 'text-rose-400',
+}
+
+export function GameStatus({ status, names }: GameStatusProps) {
   if (status.type === 'won') {
     return (
-      <p className="text-2xl font-bold text-yellow-400">
-        Jugador {status.winner} gana!
+      <p className={`text-2xl font-bold ${playerColor[status.winner]}`}>
+        {names[status.winner]} gana! 🏆
       </p>
     )
   }
 
   if (status.type === 'draw') {
-    return <p className="text-2xl font-bold text-slate-300">Empate!</p>
+    return <p className="text-2xl font-bold text-slate-300">Empate! 🤝</p>
   }
 
   return (
     <p className="text-lg text-slate-400">
-      Turno del jugador{' '}
-      <span className="font-bold text-white">{status.currentPlayer}</span>
+      Turno de{' '}
+      <span className={`font-bold ${playerColor[status.currentPlayer]}`}>
+        {names[status.currentPlayer]}
+      </span>
     </p>
   )
 }

--- a/src/features/game/PlayerNames.tsx
+++ b/src/features/game/PlayerNames.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react'
+import type { PlayerNames } from './usePlayerNames'
+import type { Player } from '@/types'
+
+interface PlayerNamesProps {
+  names: PlayerNames
+  onSetName: (player: Player, name: string) => void
+}
+
+interface EditableNameProps {
+  player: Player
+  name: string
+  colorClass: string
+  dotClass: string
+  onSetName: (player: Player, name: string) => void
+}
+
+function EditableName({ player, name, colorClass, dotClass, onSetName }: EditableNameProps) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(name)
+
+  function handleBlur() {
+    onSetName(player, draft)
+    setEditing(false)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      onSetName(player, draft)
+      setEditing(false)
+    }
+    if (e.key === 'Escape') {
+      setDraft(name)
+      setEditing(false)
+    }
+  }
+
+  return (
+    <span className={`flex items-center gap-1.5 text-sm font-semibold ${colorClass}`}>
+      <span className={`w-2 h-2 rounded-full ${dotClass}`} />
+      {player} —{' '}
+      {editing ? (
+        <input
+          autoFocus
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          className="bg-transparent border-b border-current outline-none w-24 text-sm"
+          maxLength={20}
+        />
+      ) : (
+        <button
+          onClick={() => { setDraft(name); setEditing(true) }}
+          className="underline underline-offset-2 decoration-dotted hover:opacity-80 transition-opacity cursor-pointer"
+          title="Clic para editar nombre"
+        >
+          {name}
+        </button>
+      )}
+    </span>
+  )
+}
+
+export function PlayerNames({ names, onSetName }: PlayerNamesProps) {
+  return (
+    <div className="flex gap-6">
+      <EditableName player="X" name={names.X} colorClass="text-indigo-400" dotClass="bg-indigo-400" onSetName={onSetName} />
+      <EditableName player="O" name={names.O} colorClass="text-rose-400" dotClass="bg-rose-400" onSetName={onSetName} />
+    </div>
+  )
+}

--- a/src/features/game/usePlayerNames.ts
+++ b/src/features/game/usePlayerNames.ts
@@ -1,0 +1,21 @@
+import { useState, useCallback } from 'react'
+import type { Player } from '@/types'
+
+export interface PlayerNames {
+  X: string
+  O: string
+}
+
+const DEFAULT_NAMES: PlayerNames = { X: 'Jugador 1', O: 'Jugador 2' }
+
+export function usePlayerNames() {
+  const [names, setNames] = useState<PlayerNames>({ ...DEFAULT_NAMES })
+
+  const setName = useCallback((player: Player, name: string) => {
+    const trimmed = name.trim()
+    if (trimmed.length === 0) return
+    setNames(prev => ({ ...prev, [player]: trimmed }))
+  }, [])
+
+  return { names, setName }
+}


### PR DESCRIPTION
## Summary
- Los jugadores pueden editar su nombre haciendo clic sobre él
- `usePlayerNames` hook con estado de nombres (defecto: "Jugador 1" / "Jugador 2")
- `PlayerNames.tsx` componente con inputs inline, confirmación con Enter/blur, cancelación con Escape
- `GameStatus` ahora muestra el nombre real del jugador en vez de X/O

## Archivos modificados
- `src/features/game/usePlayerNames.ts` — nuevo hook
- `src/features/game/PlayerNames.tsx` — nuevo componente con edición inline
- `src/features/game/GameStatus.tsx` — acepta prop `names` y muestra nombre real
- `src/App.tsx` — integra `usePlayerNames` y `PlayerNames`

## Test plan
- [ ] Clic sobre "Jugador 1" → input editable
- [ ] Enter guarda el nombre; Escape cancela
- [ ] Blur (clic fuera) también guarda
- [ ] GameStatus muestra el nombre actualizado
- [ ] Nombre vacío no se guarda

⚠️ **Conflicto esperado en `App.tsx` y `GameStatus.tsx`** con las otras dos ramas — mergear #7 y #8 primero

🤖 Generated with [Claude Code](https://claude.com/claude-code)